### PR TITLE
removed excess raycast on door

### DIFF
--- a/Anomalous Studios/Assets/Scripts/PlayerController/PlayerActions.cs
+++ b/Anomalous Studios/Assets/Scripts/PlayerController/PlayerActions.cs
@@ -341,7 +341,7 @@ public class PlayerActions : MonoBehaviour
     {
         if (!_playerController.GetPlayerJournal().GetInJournal())
         {
-            DoorController dc = RayCastDoor();
+            /*DoorController dc = RayCastDoor();
 
             if (dc != null)
             {
@@ -350,7 +350,7 @@ public class PlayerActions : MonoBehaviour
                     dc.ToggleDoor();
                     return;
                 }
-            }
+            }*/
 
             _playerController.GetItemHotbar().UseItem();
         }
@@ -372,7 +372,7 @@ public class PlayerActions : MonoBehaviour
     /// opening/closing with LMB click when door is unlocked
     /// </summary>
     /// <returns>returns the door controller script if raycast on door successful</returns>
-    public DoorController RayCastDoor()
+    /*public DoorController RayCastDoor()
     {
         float interactRange = 10.0f;
 
@@ -385,5 +385,5 @@ public class PlayerActions : MonoBehaviour
         }
 
         return null;
-    }
+    }*/
 }

--- a/Anomalous Studios/Assets/Scripts/PlayerController/PlayerInputBindings.cs
+++ b/Anomalous Studios/Assets/Scripts/PlayerController/PlayerInputBindings.cs
@@ -154,8 +154,6 @@ public class PlayerInputBindings : MonoBehaviour
 
     private void OnOpenHandbookPerformed(InputAction.CallbackContext ctx)
     {
-        // Set PlayerController's ViewedHandbook variable to true
-        _playerController.ViewedHandbook = true;
         _playerController.GetPlayerJournal().ToggleHandbook();
     }
 

--- a/Anomalous Studios/Assets/Scripts/PlayerController/PlayerJournal.cs
+++ b/Anomalous Studios/Assets/Scripts/PlayerController/PlayerJournal.cs
@@ -13,6 +13,7 @@ public class PlayerJournal : MonoBehaviour
     private PlayerController _playerController;
     private ElevatorController _elevatorController;
 
+    private bool _firstTimeViewed = false;
     // Getter Methods
     public bool GetInJournal() { return _inJournal; }
 
@@ -42,6 +43,11 @@ public class PlayerJournal : MonoBehaviour
         }
 
         // Ensures that the player must view the handbook and have collected all policies in the elevator before elevator's open button is enabled
-        if (_elevatorController.NotesCount() <= 0 && _playerController.ViewedHandbook) _elevatorController.GetOpenButton().Enable();
+        if (_elevatorController.NotesCount() <= 0 && !_playerController.ViewedHandbook)
+        {
+            // Set PlayerController's ViewedHandbook variable to true
+            _playerController.ViewedHandbook = true;
+            _elevatorController.GetOpenButton().Enable();
+        }
     }
 }


### PR DESCRIPTION
player can use LMB and F key to unlock and open door. after that player can only use F key to open/close door.

fixed a bug when player opens the handbook, it enables the elevator open button again